### PR TITLE
Refine transcription using Claude

### DIFF
--- a/aws-captioner/Gemfile
+++ b/aws-captioner/Gemfile
@@ -1,5 +1,6 @@
 source "https://rubygems.org"
 
+gem 'aws-sdk-bedrockruntime'
 gem 'aws-sdk-transcribestreamingservice'
 gem 'aws-sdk-translate'
 gem 'faraday'

--- a/aws-captioner/Gemfile.lock
+++ b/aws-captioner/Gemfile.lock
@@ -3,6 +3,9 @@ GEM
   specs:
     aws-eventstream (1.3.0)
     aws-partitions (1.1020.0)
+    aws-sdk-bedrockruntime (1.34.0)
+      aws-sdk-core (~> 3, >= 3.210.0)
+      aws-sigv4 (~> 1.5)
     aws-sdk-core (3.214.0)
       aws-eventstream (~> 1, >= 1.3.0)
       aws-partitions (~> 1, >= 1.992.0)
@@ -35,6 +38,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  aws-sdk-bedrockruntime
   aws-sdk-transcribestreamingservice
   aws-sdk-translate
   base64

--- a/aws-captioner/captioner.rb
+++ b/aws-captioner/captioner.rb
@@ -3,9 +3,10 @@
 require_relative './io'
 require_relative './watchdog'
 require_relative './transcribe_engine'
+require_relative './refiner'
 require_relative './translate_engine'
 
-CaptionData = Data.define(:result_id, :is_partial, :transcript, :translated_transcript)
+CaptionData = Data.define(:result_id, :is_partial, :transcript, :transcript_refined, :translated_transcript)
 
 watchdog = Watchdog.new(enabled: ARGV.delete('--watchdog'))
 watchdog.start()
@@ -13,6 +14,7 @@ watchdog.start()
 input = StdinInput.new
 engine = TranscribeEngine.new
 translator = TranslateEngine.new
+refiner = Refiner.new
 output = AppSyncOutput.new(debug: true)
 
 # Called when 256KB of input (1 second when -ar 16000) is received
@@ -29,14 +31,21 @@ engine.on_transcript_event do |event|
   event.transcript.results.each do |result|
     transcript = result.alternatives[0]&.transcript
 
-    caption = CaptionData.new(
-      result_id: result.result_id,
-      is_partial: result.is_partial,
-      transcript: transcript,
-      translated_transcript: translator&.translate(text: transcript) # 富豪的に呼んでいるが、is_partial: false のときだけでもいいかも？
-    )
+    if transcript
+      if !result.is_partial
+        refined = refiner.refine(transcript)
+      end
 
-    output.feed(caption)
+      caption = CaptionData.new(
+        result_id: result.result_id,
+        is_partial: result.is_partial,
+        transcript: transcript,
+        transcript_refined: refined,
+        translated_transcript: translator&.translate(text: transcript) # 富豪的に呼んでいるが、is_partial: false のときだけでもいいかも？
+      )
+
+      output.feed(caption)
+    end
   end
 end
 

--- a/aws-captioner/io.rb
+++ b/aws-captioner/io.rb
@@ -71,6 +71,7 @@ class AppSyncOutput < GenericOutput
   def handle(caption)
     if @debug
       $stderr.puts "Ja (orig): #{caption.transcript}"
+      $stderr.puts "Ja (refn): #{caption.transcript_refined}"
       $stderr.puts "En (tnsl): #{caption.translated_transcript}"
       $stderr.puts ""
     end

--- a/aws-captioner/refiner.rb
+++ b/aws-captioner/refiner.rb
@@ -1,0 +1,50 @@
+require 'aws-sdk-bedrockruntime'
+
+class Refiner
+  def initialize
+    @bedrock = Aws::BedrockRuntime::Client.new(region: 'ap-northeast-1')
+  end
+
+  def refine(text)
+    # Skip if the transcription is too short. It won't produce good results anyway.
+    if text.length < 20
+      return nil
+    end
+
+    begin
+      invocation = @bedrock.invoke_model(
+        model_id: 'anthropic.claude-3-5-sonnet-20240620-v1:0',
+        content_type: 'application/json',
+        accept: 'application/json',
+        body: JSON.generate({
+          anthropic_version: "bedrock-2023-05-31",
+          max_tokens: 1000,
+          messages: [
+            {
+              role: "user",
+              content: <<~PROMPT
+                これはRubyに関するカンファレンスの発表の書き起こしです。以下のルールにしたがって、書き起こしを読みやすくしてください。
+
+                - 「えっと」や「まー」などのフィラーを取り除いてください
+                - Ruby に関連しそうな用語は正しい表記にしてください（「ルビー」→  Ruby など）
+                - 以上に述べた変更以外は行わず、なるべく元の書き起こしをそのまま出力する。
+
+                読みやすくなった書き起こしのみを出力すること。
+
+                #{text}
+              PROMPT
+            }
+          ]
+        })
+      )
+    rescue Aws::BedrockRuntime::Errors::ServiceError => e
+      p e
+      return nil
+    end
+
+    # Block until entire response is ready
+    response_io = invocation.body
+    response = response_io.string
+    JSON.parse(response)["content"].first["text"]
+  end
+end


### PR DESCRIPTION
以下の処理を Claude にさせます。処理速度重視で 3.5 Sonnet を選択。3.5 Haiku はより速いが中身がイマイチ。

- フィラー（「あのー」「えっと」）の除去
  - Amazon Transcribe はフィラーも含めて文字起こしする傾向
- カタカナで書き起こされた専門用語や、書き起こしに失敗した語の補正
  - "ルビー" → Ruby
  - "アップ量記" → アプリケーション