### PR TITLE
is_partial であっても、文を単位として refine する

### DIFF
--- a/aws-captioner/captioner.rb
+++ b/aws-captioner/captioner.rb
@@ -14,7 +14,7 @@ watchdog.start()
 input = StdinInput.new
 engine = TranscribeEngine.new
 translator = TranslateEngine.new
-refiner = Refiner.new(backend: :bedrock)
+refiner = Refiner.new(backend: :anthropic)
 output = AppSyncOutput.new(debug: true)
 
 # Called when 256KB of input (1 second when -ar 16000) is received
@@ -32,9 +32,7 @@ engine.on_transcript_event do |event|
     transcript = result.alternatives[0]&.transcript
 
     if transcript
-      if !result.is_partial
-        refined = refiner.refine(transcript)
-      end
+      refined = refiner.refine(transcript, result.is_partial)
 
       caption = CaptionData.new(
         result_id: result.result_id,


### PR DESCRIPTION
Amazon Transcribe の partial は (a) 無音区間 (b) 話者の交代 をもって partial の区切りとしている。

> Amazon Transcribe breaks up the incoming audio stream based on natural speech segments, such as a change in speaker or a pause in the audio.
> https://docs.aws.amazon.com/transcribe/latest/dg/streaming-partial-results.html

この結果、とめどなく話し続けるタイプの話者はかなり長時間 partial の終わりが訪れず、refine の機会が訪れない。
そこで、Refiner のなかで句点「。」を検出したら、そこを境界として refine してしまうことにする。

Claude を何度も呼び出すと破産するので、is_partial であっても「。」が出力された前の部分はそう変化しない性質を利用して結果をキャッシュする。